### PR TITLE
disable NSAppTransportSecurity

### DIFF
--- a/QuickStart/Info.plist
+++ b/QuickStart/Info.plist
@@ -39,5 +39,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+	  <!--Include to allow all connections (DANGER)-->
+	  <key>NSAllowsArbitraryLoads</key>
+	      <true/>
+	</dict>	
 </dict>
 </plist>


### PR DESCRIPTION
This is temporary solution for supporting ios9, app needs to load arbitrary content so i decided to disable ATS