### PR TITLE
Improve consistency of output messages in quick install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -33,22 +33,23 @@ INSTALL_DIR="$HOME/Downloads/quick-start-ios-master"
 mkdir -p "$INSTALL_DIR"
 
 # Download the latest Quick Start project from Github
+echo "1: Downloading latest Quick Start project..."
 curl -sSL https://github.com/layerhq/quick-start-ios/archive/master.tar.gz | tar -zx -C $HOME/Downloads
 echo "QuickStart has been installed in ~/Downloads/quick-start-ios-master."
 
 # Update the generic XCode project with your App ID
 
 if [[ "$1" =~ [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} ]]; then
-	echo "2. Injecting App ID: $1 in the project"	
+	echo "2: Injecting App ID: $1 in the project..."	
 	sed -i '' -e "s#LQSLayerAppIDString \= \@\"LAYER_APP_ID\"#LQSLayerAppIDString = \@\"$1\"#" $INSTALL_DIR/QuickStart/LQSAppDelegate.m
 else
-	echo "2: Skipping Step - No Valid App ID provided."	
+	echo "2: Skipping App ID injection - No Valid App ID provided."	
 fi
 
 # Install the latest LayerKit using Cocoapods
 
 cd $INSTALL_DIR
-echo "3: Running 'pod install' to download latest LayerKit via cocoapods (This may take a few minutes)."
+echo "3: Running 'pod install' to download latest LayerKit via cocoapods (This may take a few minutes)..."
 hash pod >/dev/null && /usr/bin/env pod install || {
       echo "You need to install cocoapods to continue: http://cocoapods.org"
       exit 1
@@ -56,7 +57,7 @@ hash pod >/dev/null && /usr/bin/env pod install || {
 
 # Launch XCode
 
-echo "4. Congrats, you're finished! Now opening XCode. Press CMD-R to run the Project"
+echo "4: Congrats, you're finished! Now opening Xcode. Press CMD-R to run the Project"
 open "$INSTALL_DIR/QuickStart.xcworkspace"
 open "https://developer.layer.com/docs/quick-start/ios"
 


### PR DESCRIPTION
* Script was missing an output for step 1. Added for consistency
* Unify to using colons after numbers
* Use ellipsis to indicate a running task
* `XCode` > `Xcode`