### PR TITLE
Update LQSAppDelegate.m

### DIFF
--- a/QuickStart/LQSAppDelegate.m
+++ b/QuickStart/LQSAppDelegate.m
@@ -93,7 +93,10 @@ static NSString *const LQSLayerAppIDString = @"LAYER_APP_ID";
         [self setupPushNotificationOptions];
     } else {
         // Register device for iOS7
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         [application registerForRemoteNotificationTypes:UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeBadge];
+#pragma clang diagnostic pop
     }
 }
 


### PR DESCRIPTION
Suppress link warnings in XCode for this deprecated library call.

Eliminating the XCode warning will reduce distractions for developers using Layer's iOS Quick Start application.
